### PR TITLE
Feature/user last report

### DIFF
--- a/src/controllers/reportController.ts
+++ b/src/controllers/reportController.ts
@@ -17,10 +17,25 @@ class ReportController implements Controller {
   private initializeRoutes() {
     this.router.get(`${this.path}`, this.getAllReports);
     this.router.get(`${this.path}/:id`, this.getReportById);
+    this.router.get(`${this.path}/lastReport/:id`, this.getReportByUserAndStatus);
     this.router.post(`${this.path}`, this.createReport);
     this.router.put(`${this.path}`, this.updateReport);
     this.router.delete(`${this.path}/:id`, this.deleteReportById);
   }
+
+  private getReportByUserAndStatus = async (request: Request, response: Response) => {
+    const { id } = request.params;
+    try {
+      if (id) {
+        return response.status(200)
+          .json(await this.reportService.getReportByUserAndStatus(id));
+      }
+      return response.status(404);
+    } catch (err) {
+      return response.status(404)
+        .json(err.errors);
+    }
+  };
 
   private getReportById = async (request: Request, response: Response) => {
     const { id } = request.params;

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -1,4 +1,4 @@
-import ReportStatus from 'helpers/enums/reportStatus.enum';
+import ReportStatus from '../helpers/enums/reportStatus.enum';
 import ReportModel from '../models/report';
 import ReportInterface from '../interfaces/report.interface';
 
@@ -21,12 +21,10 @@ export default class ReportService {
 
     // Single report which is completed and the last updated
     if (reports === null || reports.length === 0) {
-      console.log('in report == null ');
       const lastReport = await this.report.findOne({ user: userId, status: ReportStatus.complete }).sort('-updatedAt')
         .populate('user')
         .populate('projectLocation');
 
-      console.log(`lala${lastReport}`);
       return lastReport;
     }
     return reports;

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -1,3 +1,4 @@
+import ReportStatus from 'helpers/enums/reportStatus.enum';
 import ReportModel from '../models/report';
 import ReportInterface from '../interfaces/report.interface';
 
@@ -8,6 +9,28 @@ export default class ReportService {
     .findOne({ _id: id })
     .populate('user')
     .populate('projectLocation');
+
+  public getReportByUserAndStatus = async (userId: string) => {
+    // All open reports
+    const reports = await this.report
+      .find({ user: userId, status: ReportStatus.inProgress || ReportStatus.send })
+      .populate('user')
+      .populate('projectLocation');
+
+    console.log(reports);
+
+    // Single report which is completed and the last updated
+    if (reports === null || reports.length === 0) {
+      console.log('in report == null ');
+      const lastReport = await this.report.findOne({ user: userId, status: ReportStatus.complete }).sort('-updatedAt')
+        .populate('user')
+        .populate('projectLocation');
+
+      console.log(`lala${lastReport}`);
+      return lastReport;
+    }
+    return reports;
+  };
 
   public getAll = async () => this.report.find();
 


### PR DESCRIPTION
This PR adds an endpoint with the corresponding domain logic to search for reports that have been completed per user with a max of 1. Or return all open reports with the `Send` or `InProgress` for the user.

### What to test?

1. Make sure that you have data in your DB that you know has a updateAt field, remember which report is the latest based on the updatedAt field.
2. If you have reports that have the send or InProgress status, all of them should be returned.
3. If you have no reports that match InProgress or Send status the last report that is completed should be returned(Last means last updatedAt field).

Make sure to test both cases, with and without completed status.