### PR TITLE
added docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:14 as base
+
+WORKDIR /home/node/app
+
+COPY package*.json ./
+
+RUN npm i
+
+COPY . .
+
+FROM base as production
+
+ENV NODE_PATH=./build
+
+RUN npm run build
+
+CMD ["npm", "run","server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 as base
+FROM node:16.3.0-alpine as base
 
 WORKDIR /home/node/app
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "build": "tsc",
     "lint": "npx eslint src/",
-    "seed": "ts-node src/helpers/seed.ts"
+    "seed": "ts-node src/helpers/seed.ts",
+    "server":"ts-node ./src/server.ts"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This PR adds docker support for the backend.

### What to test
Test that the docker file works as expected. Make sure to change the connection string to not use localhost but host.docker.internal instead.

1. run the following command in the repo root. `docker build -t snelmelderbackend .` 
2. run the newly createad image as a container. `docker run -p 5000:5000 -e MONGODB_CONNECTION_STRING=mongodb://host.docker.internal:27017/SnelMelder snelmelderbackend`
3. Test that application and database work just fine.